### PR TITLE
Allow creation of new users via social provider

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => null, 'name' => array_key_exists('name', $user) ? $user['name'] : '',
+            'id' => $user['id'], 'nickname' => null, 'name' => array_get($user, 'name'),
             'email' => null, 'avatar' => null,
         ]);
     }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -47,7 +47,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function mapUserToObject(array $user)
     {
         return (new User())->setRaw($user)->map([
-            'id' => $user['id'], 'nickname' => null, 'name' => $user['name'],
+            'id' => $user['id'], 'nickname' => null, 'name' => array_key_exists('name', $user) ? $user['name'] : '',
             'email' => null, 'avatar' => null,
         ]);
     }


### PR DESCRIPTION
Without this change, you'll get a php error when trying to build a sign up form using social media prefill stuff.
Obviously, the user creation still needs to be handled in own program code.
